### PR TITLE
Upgrade to Spring AI 2.0.0-RC1 and Cosmos DB dependencies 1.0.0-RC1

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The personal shopper example includes 3 agents to handle various customer servic
 - [Azure Developer CLI (azd)](https://learn.microsoft.com/azure/developer/azure-developer-cli/install-azd) **(recommended for deployment)**
 - [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) (required by azd)
 - [Maven](https://maven.apache.org/install.html) 3.8.1 or later
-- [Java 17](https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html) or later
+- [Java 21](https://adoptium.net/temurin/releases/?version=21) or later (required by Spring Boot 4.x and Spring AI 2.x)
 
 > **Note:** All Azure resources (Cosmos DB, OpenAI, Managed Identity, etc.) are provisioned automatically using Bicep via `azd up`. No manual portal setup required.
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,10 +9,9 @@
     <packaging>jar</packaging>
 
     <properties>
-        <java.version>17</java.version>
-        <spring.boot.version>3.2.2</spring.boot.version>
-        <!-- Using version 1.1.2 which includes native chat memory repository -->
-        <spring.ai.version>1.1.2</spring.ai.version>
+        <java.version>21</java.version>
+        <spring.boot.version>4.1.0-RC1</spring.boot.version>
+        <spring.ai.version>2.0.0-RC1</spring.ai.version>
     </properties>
 
     <repositories>
@@ -70,15 +69,17 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-starter-model-azure-openai</artifactId>
+            <artifactId>spring-ai-starter-model-openai</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.ai</groupId>
+            <groupId>com.azure.spring.ai</groupId>
             <artifactId>spring-ai-azure-cosmos-db-store</artifactId>
+            <version>1.0.0-RC1</version>
         </dependency>
         <dependency>
-            <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-starter-model-chat-memory-repository-cosmos-db</artifactId>
+            <groupId>com.azure.spring.ai</groupId>
+            <artifactId>spring-ai-model-chat-memory-repository-cosmos-db</artifactId>
+            <version>1.0.0-RC1</version>
         </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>

--- a/src/main/java/com/cosmos/multiagent/agent/orchestrator/AgentOrchestrator.java
+++ b/src/main/java/com/cosmos/multiagent/agent/orchestrator/AgentOrchestrator.java
@@ -75,12 +75,17 @@ public class AgentOrchestrator {
         tools.add(agentTransfer);
 
         // Build and call the chat client with memory advisor
+        // Memory advisor must be outermost (lowest order) so ToolCallAdvisor's
+        // internal retries don't pass through memory on each tool call iteration
         String response = ChatClient.builder(chatModel)
                 .build()
-                .prompt(agent.systemPrompt())
-                .advisors(MessageChatMemoryAdvisor.builder(chatMemory)
-                        .conversationId(sessionId)
-                        .build())
+                .prompt()
+                .system(agent.systemPrompt())
+                .advisors(spec -> spec
+                        .advisors(MessageChatMemoryAdvisor.builder(chatMemory)
+                                .order(Integer.MIN_VALUE)
+                                .build())
+                        .param("chat_memory_conversation_id", sessionId))
                 .user(input)
                 .tools(tools.toArray())
                 .call()

--- a/src/main/java/com/cosmos/multiagent/api/MultiAgentConfig.java
+++ b/src/main/java/com/cosmos/multiagent/api/MultiAgentConfig.java
@@ -2,12 +2,13 @@
 // Licensed under the MIT License.
 package com.cosmos.multiagent.api;
 
-import com.azure.ai.openai.OpenAIClient;
-import com.azure.ai.openai.OpenAIClientBuilder;
 import com.azure.core.credential.TokenCredential;
 import com.azure.cosmos.CosmosAsyncClient;
 import com.azure.cosmos.CosmosClientBuilder;
 import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.spring.ai.chat.memory.repository.cosmosdb.CosmosDBChatMemoryRepository;
+import com.azure.spring.ai.chat.memory.repository.cosmosdb.CosmosDBChatMemoryRepositoryConfig;
+import com.azure.spring.ai.vectorstore.cosmosdb.CosmosDBVectorStore;
 import com.azure.spring.data.cosmos.config.AbstractCosmosConfiguration;
 import com.azure.spring.data.cosmos.config.CosmosConfig;
 import com.azure.spring.data.cosmos.repository.config.EnableCosmosRepositories;
@@ -15,17 +16,10 @@ import com.azure.spring.data.cosmos.core.ResponseDiagnostics;
 import com.azure.spring.data.cosmos.core.ResponseDiagnosticsProcessor;
 import io.micrometer.observation.ObservationRegistry;
 import org.slf4j.LoggerFactory;
-import org.springframework.ai.azure.openai.AzureOpenAiChatModel;
-import org.springframework.ai.azure.openai.AzureOpenAiChatOptions;
-import org.springframework.ai.azure.openai.AzureOpenAiEmbeddingModel;
-import org.springframework.ai.azure.openai.AzureOpenAiEmbeddingOptions;
-import org.springframework.ai.chat.client.ChatClient;
-import org.springframework.ai.chat.model.ChatModel;
-import org.springframework.ai.document.MetadataMode;
+import org.springframework.ai.chat.memory.ChatMemoryRepository;
 import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.embedding.TokenCountBatchingStrategy;
 import org.springframework.ai.vectorstore.VectorStore;
-import org.springframework.ai.vectorstore.cosmosdb.CosmosDBVectorStore;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -51,64 +45,12 @@ public class MultiAgentConfig extends AbstractCosmosConfiguration {
     @Value("${spring.cloud.azure.cosmos.responseDiagnosticsEnabled}")
     private static boolean responseDiagnosticsEnabled;
 
-    @Value("${spring.ai.azure.openai.endpoint}")
-    private String azureOpenAIEndpoint;
-
-    @Value("${spring.ai.azure.openai.chat.options.deployment-name}")
-    private String chatDeploymentName;
-
-    @Value("${spring.ai.azure.openai.chat.options.temperature}")
-    private double chatTemperature;
-
-    @Value("${spring.ai.azure.openai.embedding.options.deployment-name}")
-    private String embeddingDeploymentName;
-
     @Bean
     public TokenCredential tokenCredential() {
         return new DefaultAzureCredentialBuilder().build();
     }
 
-    @Bean
-    public OpenAIClient azureOpenAIClient(TokenCredential tokenCredential) {
-        return new OpenAIClientBuilder()
-                .credential(tokenCredential)
-                .endpoint(azureOpenAIEndpoint)
-                .buildClient();
-    }
-
-    @Bean
-    public OpenAIClientBuilder azureOpenAIClientBuilder(TokenCredential tokenCredential) {
-        return new OpenAIClientBuilder()
-                .credential(tokenCredential)
-                .endpoint(azureOpenAIEndpoint);
-    }
-
-    @Bean
-    public ChatModel azureOpenAiChatModel(
-            OpenAIClientBuilder openAIClientBuilder,
-            ObservationRegistry observationRegistry) {
-        AzureOpenAiChatOptions options = AzureOpenAiChatOptions.builder()
-                .deploymentName(chatDeploymentName)
-                .temperature(chatTemperature)
-                .build();
-        // Use builder pattern which should handle toolCallingManager internally
-        return AzureOpenAiChatModel.builder()
-                .openAIClientBuilder(openAIClientBuilder)
-                .defaultOptions(options)
-                .observationRegistry(observationRegistry)
-                .build();
-    }
-
-    @Bean
-    public EmbeddingModel azureOpenAiEmbeddingModel(OpenAIClient openAIClient) {
-        AzureOpenAiEmbeddingOptions options = AzureOpenAiEmbeddingOptions.builder()
-                .deploymentName(embeddingDeploymentName)
-                .build();
-        return new AzureOpenAiEmbeddingModel(openAIClient, MetadataMode.EMBED, options);
-    }
-
     // Single CosmosAsyncClient shared between Spring Data Cosmos and Spring AI
-    // Vector Store
     @Bean
     public CosmosAsyncClient cosmosAsyncClient() {
         return new CosmosClientBuilder()
@@ -116,11 +58,6 @@ public class MultiAgentConfig extends AbstractCosmosConfiguration {
                 .credential(new DefaultAzureCredentialBuilder().build())
                 .contentResponseOnWriteEnabled(true)
                 .buildAsyncClient();
-    }
-
-    @Bean
-    public ChatClient chatClient(AzureOpenAiChatModel chatModel) {
-        return ChatClient.builder(chatModel).build();
     }
 
     @Bean
@@ -141,7 +78,17 @@ public class MultiAgentConfig extends AbstractCosmosConfiguration {
         return this.databaseName;
     }
 
-    // Manual VectorStore bean using Spring AI 1.0.0-SNAPSHOT (has Builder fix)
+    @Bean
+    public ChatMemoryRepository chatMemoryRepository(CosmosAsyncClient cosmosAsyncClient) {
+        CosmosDBChatMemoryRepositoryConfig config = CosmosDBChatMemoryRepositoryConfig.builder()
+                .withCosmosClient(cosmosAsyncClient)
+                .withDatabaseName(databaseName)
+                .withContainerName("ChatMemory")
+                .withPartitionKeyPath("/conversationId")
+                .build();
+        return CosmosDBChatMemoryRepository.create(config);
+    }
+
     @Bean
     public VectorStore vectorStore(
             ObservationRegistry observationRegistry,

--- a/src/main/java/com/cosmos/multiagent/api/MultiAgentService.java
+++ b/src/main/java/com/cosmos/multiagent/api/MultiAgentService.java
@@ -8,7 +8,7 @@ import com.cosmos.multiagent.agent.memory.CosmosChatSession;
 import com.cosmos.multiagent.agent.models.ChatSession;
 import com.cosmos.multiagent.agent.orchestrator.AgentOrchestrator;
 import org.springframework.ai.chat.memory.ChatMemory;
-import org.springframework.ai.chat.memory.repository.cosmosdb.CosmosDBChatMemoryRepository;
+import org.springframework.ai.chat.memory.ChatMemoryRepository;
 import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import com.cosmos.multiagent.api.tools.OrderItem;
 import com.cosmos.multiagent.api.tools.RefundItem;
@@ -67,7 +67,7 @@ public class MultiAgentService {
     private ProductRepository productsRepository;
 
     @Autowired
-    private CosmosDBChatMemoryRepository chatMemoryRepository;
+    private ChatMemoryRepository chatMemoryRepository;
 
     private AgentOrchestrator orchestrator;
     private CosmosChatSession chatSession;

--- a/src/main/resources/application.properties.example
+++ b/src/main/resources/application.properties.example
@@ -6,13 +6,13 @@ spring.ai.chat.memory.repository.cosmosdb.endpoint=${AZURE_COSMOSDB_ENDPOINT}
 spring.ai.chat.memory.repository.cosmosdb.database-name=MultiAgentDB
 spring.ai.chat.memory.repository.cosmosdb.container-name=ChatMemory
 spring.ai.chat.memory.repository.cosmosdb.partition-key-path=/conversationId
-spring.ai.azure.openai.endpoint=${AZURE_OPENAI_ENDPOINT}
-spring.ai.azure.openai.embedding.options.deployment-name=text-embedding-3-large
-spring.ai.azure.openai.chat.options.deployment-name=gpt-4o-mini
-spring.ai.azure.openai.chat.options.temperature=0.7
+spring.ai.openai.base-url=${AZURE_OPENAI_ENDPOINT}
+spring.ai.openai.microsoft-foundry=true
+spring.ai.openai.embedding.microsoft-deployment-name=text-embedding-3-large
+spring.ai.openai.chat.microsoft-deployment-name=gpt-4o-mini
+spring.ai.openai.chat.options.temperature=0.7
 spring.autoconfigure.exclude=\
   org.springframework.ai.autoconfigure.vectorstore.cosmosdb.CosmosDBVectorStoreAutoConfiguration,\
   org.springframework.ai.vectorstore.cosmosdb.autoconfigure.CosmosDBVectorStoreAutoConfiguration,\
-  org.springframework.ai.model.azure.openai.autoconfigure.AzureOpenAiChatAutoConfiguration,\
-  org.springframework.ai.model.azure.openai.autoconfigure.AzureOpenAiEmbeddingAutoConfiguration
+  com.azure.spring.ai.autoconfigure.vectorstore.cosmosdb.CosmosDBVectorStoreAutoConfiguration
 


### PR DESCRIPTION
- Update spring.ai.version to 2.0.0-RC1
- Update spring.boot.version to 4.1.0-RC1
- Update cosmos dependencies from SNAPSHOT to released 1.0.0-RC1
- Update README Java prerequisite to Java 21
- Adapt code to Spring AI 2.0 API changes